### PR TITLE
wip: fix windows compat

### DIFF
--- a/modules/pwa-tools/bin/ngu-app-shell.ts
+++ b/modules/pwa-tools/bin/ngu-app-shell.ts
@@ -1,4 +1,6 @@
-#!/usr/bin/env node_modules/.bin/ts-node
+#!/usr/bin/env node
+
+require('ts-node/register');
 
 import minimist = require('minimist');
 import {requiredArgs} from '../lib/common/args';

--- a/modules/pwa-tools/bin/ngu-firebase-push.ts
+++ b/modules/pwa-tools/bin/ngu-firebase-push.ts
@@ -1,4 +1,6 @@
-#!/usr/bin/env node_modules/.bin/ts-node
+#!/usr/bin/env node
+
+require('ts-node/register');
 
 import minimist = require('minimist');
 import * as fs from 'fs';

--- a/modules/pwa-tools/bin/ngu-ls-routes.ts
+++ b/modules/pwa-tools/bin/ngu-ls-routes.ts
@@ -1,4 +1,6 @@
-#!/usr/bin/env node_modules/.bin/ts-node
+#!/usr/bin/env node
+
+require('ts-node/register');
 
 import minimist = require('minimist');
 
@@ -55,4 +57,3 @@ lsRoutes({appModule, baseHref, loadChildrenRoot})
     console.error('An error occurred while attempting to read routes', err);
     process.exit(1);
   });
-  

--- a/modules/pwa-tools/bin/ngu-sw-manifest.ts
+++ b/modules/pwa-tools/bin/ngu-sw-manifest.ts
@@ -1,4 +1,6 @@
-#!/usr/bin/env node_modules/.bin/ts-node
+#!/usr/bin/env node
+
+require('ts-node/register');
 
 import minimist = require('minimist');
 import * as fs from 'fs';


### PR DESCRIPTION
Trying to build AIO on windows would show this error message:
```
kamik@T460p MINGW64 /d/work/angular/aio (master)
$ yarn sw-manifest
yarn sw-manifest v0.24.6
$ ngu-sw-manifest --dist dist --in ngsw-manifest.json --out dist/ngsw-manifest.json
'node_modules' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
```

It happened because `node_modules/.bin/ts-node` is not a valid binary in windows.

This PR fixes the problem by using `node` as the binary and immediately registering `ts-node`.